### PR TITLE
Fix variable typo in update_user

### DIFF
--- a/src/routes/auth/endpoints.py
+++ b/src/routes/auth/endpoints.py
@@ -142,13 +142,13 @@ async def update_user(
     """
 
     if "admin" in current_user.scopes or current_user.username == name:
-        hasshed_password = get_password_hash(user.password)
+        hashed_password = get_password_hash(user.password)
         async with MongoDBConnectionManager() as db:
             await db.users.update_one(
                 {"username": name},
                 {
                     "$set": UserInDB(
-                        **user.model_dump(), hashed_password=hasshed_password
+                        **user.model_dump(), hashed_password=hashed_password
                     ).model_dump()
                 },
             )


### PR DESCRIPTION
## Summary
- fix a typo in `update_user` inside auth endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686db97b64d08320a3d77e75cd480507