### PR TITLE
Fix __aexit__ return type

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -16,7 +16,7 @@ class MongoDBConnectionManager:
         self.db = self.client[self.db_name]
         return self.db
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         _ = exc_type, exc_val, exc_tb
         if self.client:
             self.client.close()


### PR DESCRIPTION
## Summary
- ensure MongoDBConnectionManager.__aexit__ has a return type annotation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea59e32808320bb6b912f447408a3