### PR TITLE
Fix deployment instruction wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ docker-compose up -d
 
 ## Caprover
 
-User the Webhook to deploy
+Use the Webhook to deploy.


### PR DESCRIPTION
## Summary
- fix README wording for webhook deployment

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ea97243f88320a507e2e589645872